### PR TITLE
Minor bug fix where optimiser expected 2 children

### DIFF
--- a/src/optimisation.c
+++ b/src/optimisation.c
@@ -39,16 +39,20 @@ ast_node* find_conditions(ast_node* node)
     if (node->type == AstIf)
     {
         ast_node* condition = ast_get_child(node, 0);
-        ast_node* node1 = ast_get_child(condition, 0);
-        ast_node* node2 = ast_get_child(condition, 1);
-        
-        if (node1->type == AstIntegerLit && node2->type == AstIntegerLit)
-        {
-            int response = eval_condition(condition, node1, node2);
 
-            if (response != 0)
+        if (condition->children->size == 2)
+        {
+            ast_node* node1 = ast_get_child(condition, 0);
+            ast_node* node2 = ast_get_child(condition, 1);
+            
+            if (node1->type == AstIntegerLit && node2->type == AstIntegerLit)
             {
-                return ast_get_child(node, response);
+                int response = eval_condition(condition, node1, node2);
+
+                if (response != 0)
+                {
+                    return ast_get_child(node, response);
+                }
             }
         }
     }
@@ -58,7 +62,7 @@ ast_node* find_conditions(ast_node* node)
         for (size_t i = 0; i < node->children->size; i++)
         {
             ast_node* scope = find_conditions(ast_get_child(node, i));
-            if (scope != NULL)
+            if (scope)
             {
                 ast_set_child(node, i, scope);
             }
@@ -70,6 +74,5 @@ ast_node* find_conditions(ast_node* node)
 
 void optimize(module* mod, ast_node* node)
 {
-    // in progress
     find_conditions(node);
 }

--- a/units/optimise-test.tin
+++ b/units/optimise-test.tin
@@ -1,12 +1,16 @@
 fn i32 main
 {
     i32 num = 5;
+    i32 val = num;
 
-    if (4 > 5) {
+    if (3==3) {
         print "yep";
     }
-    else {
+    else if (2+2==3) {
         print "nope";
+    }
+    else {
+        print"e";
     }
 
     return 0;


### PR DESCRIPTION
Optimiser expected at least two children within if statements, only taking into consideration comparing two values and not considering a case where only one value is given, such as...

```
if (1) {}
```

Working on a sensible solution to finding and replacing constants/expressions, which will replace this code soon - this bugfix is just to prevent unnecessary errors until then.