### PR TITLE
`include` standard library support

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -9,7 +9,7 @@
             "type": "cppdbg",
             "request": "launch",
             "program": "${workspaceFolder}/build/tin.exe",
-            "args": ["units/typecheck-test.tin"],
+            "args": ["units/include_test.tin"],
             "stopAtEntry": false,
             "cwd": "${workspaceFolder}",
             "environment": [],

--- a/Makefile
+++ b/Makefile
@@ -49,4 +49,7 @@ clean:
 	-@rm -f examples/*.mod.json
 
 memcheck: tin
-	@valgrind --leak-check=full --track-origins=yes ./build/tin $(file)
+	@valgrind ./build/tin $(file)
+
+memcheck_full: tin
+	@valgrind --leak-check=full --show-leak-kinds=all --track-origins=yes ./build/tin $(file)

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ sources = src/*.c src/backend/*.c src/utils/*.c
 sources_generated =generated/lex.yy.c generated/parser.tab.c
 
 tin: dir parser.o lex.o
-	@ gcc $(flags) -Isrc -Igenerated -Werror -g -O0 $(sources) $(sources_generated) -o build/tin -lm
+	@ gcc $(flags) -Isrc -Igenerated -Werror -fsanitize=address -g -O0 $(sources) $(sources_generated) -o build/tin -lm
 
 debug_assembly:
 	@riscv64-linux-gnu-as ./examples/itoa.s -o ./examples/itoa.o

--- a/README.md
+++ b/README.md
@@ -122,16 +122,21 @@ Run the following command to fetch all of the required packages in order to buil
 1. Clone the repo
    ```sh
    $ git clone https://github.com/aaf6aa/tin.git
+   $ cd tin
    ```
-2. Make the project 
+2. Add the standard library to PATH
+   ```sh
+   $ PATH="$PATH:$(pwd)/std"
+   ```
+3. Make the project 
    ```sh
    $ make tin
    ```
-3. Compile your .tin file
+4. Compile your .tin file
    ```sh
    $ ./build/tin file-name.tin
    ```
-4. Run the executable through QEMU
+5. Run the executable through QEMU
    ```sh
    $ qemu-riscv64 ./file-name
    ```

--- a/src/ast.c
+++ b/src/ast.c
@@ -292,7 +292,7 @@ void ast_print_to_file(ast_node* node, FILE* file)
     }
     else if (node->type == AstSymbol)
     {
-        fprintf(file, ",\"symbol_id\":\"%p\",\"str_value\": \"%s\"", node->value.symbol, node->value.symbol->name);
+        fprintf(file, ",\"symbol_key\":\"%s\",\"str_value\": \"%s\"", node->value.symbol->key, node->value.symbol->name);
     }
     else if ((node->type == AstRoot || node->type == AstScope) && node->value.symbol_table->size > 0)
     {

--- a/src/ast.c
+++ b/src/ast.c
@@ -100,6 +100,10 @@ ast_node* ast_copy(ast_node* node)
     {
         copy->value.string = strdup(node->value.string);
     }
+    else if (node->type == AstRoot || node->type == AstScope)
+    {
+        copy->value.symbol_table = hashtable_copy(node->value.symbol_table);
+    }
     else if (has_dtype(node->type))
     {
         copy->value.dtype = data_type_copy(node->value.dtype);

--- a/src/ast.c
+++ b/src/ast.c
@@ -222,8 +222,20 @@ data_type* ast_find_data_type(ast_node* node)
     return 0;
 }
 
-symbol* ast_find_symbol(ast_node* node, char* name)
+symbol *ast_find_symbol(ast_node *node, char *name, void* mod_ptr)
 {
+    char* key;
+
+    if (mod_ptr != 0)
+    {
+        key = malloc(16 + strlen(name) + 1);
+        sprintf(key, "%p%s", mod_ptr, name);
+    }
+    else
+    {
+        key = strdup(name);
+    }
+
     symbol* sym = 0;
 
     // traverse up the tree and check each symbol table for the given symbol name
@@ -231,11 +243,13 @@ symbol* ast_find_symbol(ast_node* node, char* name)
     {
         if (node->type == AstRoot || node->type == AstScope)
         {
-            sym = (symbol*)hashtable_get_item(node->value.symbol_table, name);
+            sym = (symbol*)hashtable_get_item(node->value.symbol_table, key);
         }
 
         node = node->parent;
     }
+
+    free(key);
 
     return sym;
 }

--- a/src/ast.c
+++ b/src/ast.c
@@ -222,20 +222,8 @@ data_type* ast_find_data_type(ast_node* node)
     return 0;
 }
 
-symbol *ast_find_symbol(ast_node *node, char *name, void* mod_ptr)
+symbol *ast_find_symbol(ast_node *node, char *symbol_key)
 {
-    char* key;
-
-    if (mod_ptr != 0)
-    {
-        key = malloc(16 + strlen(name) + 1);
-        sprintf(key, "%p%s", mod_ptr, name);
-    }
-    else
-    {
-        key = strdup(name);
-    }
-
     symbol* sym = 0;
 
     // traverse up the tree and check each symbol table for the given symbol name
@@ -243,13 +231,11 @@ symbol *ast_find_symbol(ast_node *node, char *name, void* mod_ptr)
     {
         if (node->type == AstRoot || node->type == AstScope)
         {
-            sym = (symbol*)hashtable_get_item(node->value.symbol_table, key);
+            sym = (symbol*)hashtable_get_item(node->value.symbol_table, symbol_key);
         }
 
         node = node->parent;
     }
-
-    free(key);
 
     return sym;
 }

--- a/src/ast.h
+++ b/src/ast.h
@@ -113,7 +113,7 @@ ast_node *ast_get_current_function(ast_node *node);
 hashtable *ast_get_closest_symtable(ast_node *node);
 // searched for the closest data type in the children and their children (used for expressions)
 data_type *ast_find_data_type(ast_node *node);
-symbol *ast_find_symbol(ast_node *node, char *name, void* mod_ptr);
+symbol *ast_find_symbol(ast_node *node, char *symbol_key);
 
 char *ast_find_closest_src_line(ast_node *node);
 

--- a/src/ast.h
+++ b/src/ast.h
@@ -98,7 +98,7 @@ struct ast_node
 };
 
 ast_node *ast_new(enum ast_node_type type);
-void ast_free(ast_node *node);
+void ast_free(ast_node* node, bool keep_symbols);
 ast_node *ast_copy(ast_node *node);
 
 void ast_resize(ast_node* node);

--- a/src/ast.h
+++ b/src/ast.h
@@ -113,7 +113,7 @@ ast_node *ast_get_current_function(ast_node *node);
 hashtable *ast_get_closest_symtable(ast_node *node);
 // searched for the closest data type in the children and their children (used for expressions)
 data_type *ast_find_data_type(ast_node *node);
-symbol *ast_find_symbol(ast_node *node, char *name);
+symbol *ast_find_symbol(ast_node *node, char *name, void* mod_ptr);
 
 char *ast_find_closest_src_line(ast_node *node);
 

--- a/src/ast_nodes/definition.h
+++ b/src/ast_nodes/definition.h
@@ -25,7 +25,7 @@ void preprocess_definition(preproc_state* state, ast_node* node)
         symbol_node = ast_copy(symbol_node);
             
         ast_set_child(node->parent, ast_get_child_index(node->parent, node), symbol_node);
-        ast_free(node);
+        ast_free(node, 0);
 
         state->index_offset = -1;
     }

--- a/src/ast_nodes/identifier.h
+++ b/src/ast_nodes/identifier.h
@@ -36,8 +36,7 @@ void preprocess_identifier(preproc_state* state, ast_node* node)
     }
 
     char* identifier_name = node->value.string;
-    char* symbol_key = malloc(16 + strlen(identifier_name) + 1);
-    sprintf(symbol_key, "%p%s", namespace, identifier_name);
+    char* symbol_key = symbol_generate_key(identifier_name, namespace);
 
     if (table == 0)
     {
@@ -65,7 +64,7 @@ void preprocess_identifier(preproc_state* state, ast_node* node)
     else
     {
         // look for the symbol in all scopes above us
-        sym = ast_find_symbol(node, identifier_name, namespace);
+        sym = ast_find_symbol(node, symbol_key);
     }
 
     if (sym == 0)

--- a/src/ast_nodes/identifier.h
+++ b/src/ast_nodes/identifier.h
@@ -27,7 +27,7 @@ void preprocess_identifier(preproc_state* state, ast_node* node)
     {
         if (namespace == 0)
         {
-            preproc_error(state, node, "%scould not locate given namespace", "");
+            preproc_error(state, node, "%scould not locate given namespace\n", "");
         }
         else
         {

--- a/src/ast_nodes/identifier.h
+++ b/src/ast_nodes/identifier.h
@@ -69,8 +69,7 @@ void preprocess_identifier(preproc_state* state, ast_node* node)
 
     if (sym == 0)
     {
-        sym = symbol_new();
-        sym->name = strdup(identifier_name);
+        sym = symbol_new(identifier_name, namespace);
 
         if (!is_being_assigned_to)
         {

--- a/src/ast_nodes/identifier.h
+++ b/src/ast_nodes/identifier.h
@@ -102,5 +102,5 @@ void preprocess_identifier(preproc_state* state, ast_node* node)
 
     // replace the indentifier node with a symbol node
     ast_set_child(node->parent, index_in_parent, symbol_node);
-    ast_free(node);
+    ast_free(node, 0);
 }

--- a/src/ast_nodes/include.h
+++ b/src/ast_nodes/include.h
@@ -9,14 +9,16 @@
 
 void preprocess_include(preproc_state* state, ast_node* node)
 {
-    char* name = path_get_filename_wo_ext(node->value.string);
+    char* path = node->value.string;
+
+    char* name = path_get_filename_wo_ext(path);
     module* dependency = module_find_dependency(state->mod, name);
     free(name);
 
     if (dependency == 0)
     {
         // if the dependency doesn't exist in the program, parse it 
-        dependency = module_parse(node->value.string, state->mod);
+        dependency = module_parse(path, state->mod);
         if (dependency == 0)
         {
             preproc_error(state, node, "%scould not parse include\n", "");

--- a/src/ast_nodes/root.h
+++ b/src/ast_nodes/root.h
@@ -2,11 +2,14 @@
 
 #include "preprocessor.h"
 #include "ast.h"
+#include "symbol.h"
 
 void preprocess_root(preproc_state* state, ast_node* node)
 {
-    if (state->mod->parent == 0 && ast_find_symbol(node, "main", state->mod) == 0)
+    char* symbol_key = symbol_generate_key("main", state->mod);
+    if (state->mod->parent == 0 && ast_find_symbol(node, symbol_key) == 0)
     {
         preproc_error(state, node, "no main function defined\n"); 
     }
+    free(symbol_key);
 }

--- a/src/ast_nodes/root.h
+++ b/src/ast_nodes/root.h
@@ -5,7 +5,7 @@
 
 void preprocess_root(preproc_state* state, ast_node* node)
 {
-    if (state->mod->parent == 0 && ast_find_symbol(node, "main") == 0)
+    if (state->mod->parent == 0 && ast_find_symbol(node, "main", state->mod) == 0)
     {
         preproc_error(state, node, "no main function defined\n"); 
     }

--- a/src/backend/codegen.c
+++ b/src/backend/codegen.c
@@ -311,7 +311,7 @@ void codegen_write_postamble(FILE *file)
     gen_rodata(file);
 }
 
-bool codegen_generate(module *mod, ast_node *node, FILE *file)
+bool codegen_generate(module *mod, FILE *file)
 {
     codegen_init();
     codegen_write_preamble(file);
@@ -320,7 +320,10 @@ bool codegen_generate(module *mod, ast_node *node, FILE *file)
     write_to_file(".text\n\n");
 
     int reg;
-    reg = codegen_traverse_ast(file, node, 0);
+    reg = codegen_traverse_ast(file, mod->ast_root, 0);
+
+    // get the unique key for main function
+    char* main_function_key = symbol_generate_key("main", mod);
 
     // TODO: Clean up
     // ASM
@@ -336,7 +339,7 @@ bool codegen_generate(module *mod, ast_node *node, FILE *file)
 #ifdef TIN_DEBUG_VERBOSE
     write_to_file("\t# Call main function\n");
 #endif
-    write_to_file("\tcall\tmain\n");
+    write_to_file("\tcall\t%s\n", main_function_key);
 
     // Exit cleanly
 #ifdef TIN_DEBUG_VERBOSE

--- a/src/backend/codegen.c
+++ b/src/backend/codegen.c
@@ -140,14 +140,14 @@ int codegen_traverse_ast(FILE *file, ast_node *node, int reg)
     {
         // Symbol is first child
         ast_node *child = vector_get_item(node->children, 0);
-        gen_function(file, reg, child->value.symbol->name);
+        gen_function(file, reg, child->value.symbol->key);
         break;
     }
     case AstFunctionCall:
     {
         // Symbol is first child
         ast_node *child = vector_get_item(node->children, 0);
-        gen_function_call(file, reg, child->value.symbol->name);
+        gen_function_call(file, reg, child->value.symbol->key);
         break;
     }
     }
@@ -256,7 +256,7 @@ int codegen_traverse_ast(FILE *file, ast_node *node, int reg)
     {
         if (node->parent->type == AstAssignment)
         {
-            return gen_store_global(file, reg, node->value.symbol->name, node->value.symbol->dtype->size);
+            return gen_store_global(file, reg, node->value.symbol->key, node->value.symbol->dtype->size);
         }
         else if (node->parent->type == AstFunction)
         {
@@ -276,7 +276,7 @@ int codegen_traverse_ast(FILE *file, ast_node *node, int reg)
         else
         {
             trace("\tLoading (parent type: %s)", ast_type_names[node->parent->type]);
-            return gen_load_global(file, node->value.symbol->name, node->value.symbol->dtype->size);
+            return gen_load_global(file, node->value.symbol->key, node->value.symbol->dtype->size);
         }
     }
     case AstAssignment:

--- a/src/backend/codegen.c
+++ b/src/backend/codegen.c
@@ -351,4 +351,10 @@ bool codegen_generate(module *mod, FILE *file)
     write_to_file("\tecall\n");
 
     codegen_write_postamble(file);
+
+    // cleanup
+    free(main_function_key);
+    free(codegen_alloc_registers()); // if regs are already allocated, free them
+    rodata_free();
+    variable_freeall();
 }

--- a/src/backend/codegen.h
+++ b/src/backend/codegen.h
@@ -6,4 +6,4 @@
 #include "module.h"
 #include "utils/vector.h"
 
-bool codegen_generate(module *mod, ast_node *node, FILE *file);
+bool codegen_generate(module *mod, FILE *file);

--- a/src/backend/generators.c
+++ b/src/backend/generators.c
@@ -248,9 +248,22 @@ void variable_init()
     variables = hashtable_new();
 }
 
+void variable_freeall()
+{
+    for (int i = 0; i < variables->capacity; i++)
+    {
+        if (variables->keys[i] != NULL)
+        {
+            free(variables->items[i]);
+        }
+    }
+    hashtable_free(variables);
+}
+
 void variable_free(char *identifier)
 {
     trace("\tFreeing variable %s\n", identifier);
+    free(hashtable_get_item(variables, identifier));
     hashtable_delete_item(variables, identifier);
 }
 
@@ -291,6 +304,20 @@ void rodata_add(char *identifier, char *string)
 
     rodata[rodata_count] = entry;
     rodata_count++;
+}
+void rodata_free()
+{
+    for (int i = 0; i < rodata_count; i++)
+    {
+        rodata_entry *entry = (rodata_entry *)rodata[i];
+        if (entry == NULL)
+        {
+            continue;
+        }
+        free(entry->identifier);
+        free(entry->string);
+        free(entry);
+    }
 }
 
 void gen_rodata(FILE *file)

--- a/src/backend/generators.h
+++ b/src/backend/generators.h
@@ -23,6 +23,7 @@ void free_register(int reg);
 hashtable *variables;
 
 void variable_init();
+void variable_freeall();
 void variable_free(char *identifier);
 int variable_get(char *identifier);
 int variable_set(char *identifier, int value, int size);
@@ -45,6 +46,7 @@ static int rodata_count = 0;
 
 void rodata_init();
 void rodata_add(char *identifier, char *string);
+void rodata_free();
 void gen_rodata(FILE *file);
 
 //

--- a/src/data_type.c
+++ b/src/data_type.c
@@ -21,6 +21,11 @@ data_type* data_type_new(char* name)
 
 void data_type_free(data_type* dtype)
 {
+    if (dtype == 0)
+    {
+        return;
+    }
+
     free(dtype->name);
     free(dtype);
 }

--- a/src/module.c
+++ b/src/module.c
@@ -74,6 +74,17 @@ module* module_parse(char* path, module* parent)
         parent_dir = parent->dir;
     }
     
+    // if the include has no extension, add it back
+    char* ext = strstr(path, ".tin");
+    if (ext != 0 && (path + (int)strlen(path) - ext) == 4)
+    {
+        path = strdup(path);
+    }
+    else
+    {
+        path = path_join(2, path, ".tin");
+    }
+
     char* src_path;
     if (!(src_path = path_locate_file(path, parent_dir)))
     {
@@ -101,6 +112,7 @@ module* module_parse(char* path, module* parent)
 
 	fclose(src_file);
     free(src_path);
+    free(path);
 
     if (parser_status != 0)
     {

--- a/src/module.c
+++ b/src/module.c
@@ -68,18 +68,20 @@ module* module_parse(char* path, module* parent)
     {
         parent_dir = parent->dir;
     }
+    
+    char* src_path;
+    if (!(src_path = path_locate_file(path, parent_dir)))
+    {
+        printf("error: could not find file %s\n", path);
+        free(src_path);
+        return false;
+    }
 
-    char* relative_path = path_join(2, parent_dir, path); 
-    mod->dir = path_get_directory(relative_path);
+    FILE* src_file = fopen(src_path, "rb");
+
+    mod->dir = path_get_directory(src_path);
     mod->filename = path_get_filename(path);
     mod->name = path_get_filename_wo_ext(path);
-
-    FILE* src_file;
-	if (!(src_file = fopen(relative_path, "rb")))
-	{
-		printf("error: could not find file %s\n", path);
-		return false;
-	}
 
 	module_set_src_file(mod, src_file);
 
@@ -93,7 +95,7 @@ module* module_parse(char* path, module* parent)
 	yylex_destroy(scanner);
 
 	fclose(src_file);
-    free(relative_path);
+    free(src_path);
 
     if (parser_status != 0)
     {
@@ -101,8 +103,6 @@ module* module_parse(char* path, module* parent)
         module_free(mod);
 		return 0;
     }
-
-    //return mod;
     
     if (!preprocessor_process(mod))
     {

--- a/src/module.c
+++ b/src/module.c
@@ -23,7 +23,7 @@ module* module_new()
     return mod;
 }
 
-void module_free(module* mod)
+void module_free(module* mod, bool keep_symbols)
 {
     if (mod == 0)
     {
@@ -35,7 +35,7 @@ void module_free(module* mod)
         vector* modules_vec = hashtable_to_vector(mod->module_store);
         for (int i = 0; i < modules_vec->size; i++)
         {
-            module_free(vector_get_item(modules_vec, i));
+            module_free(vector_get_item(modules_vec, i), keep_symbols);
         }
         vector_free(modules_vec);
         hashtable_free(mod->module_store);
@@ -50,7 +50,7 @@ void module_free(module* mod)
     }
 
     free(mod->name);
-    ast_free(mod->ast_root);
+    ast_free(mod->ast_root, keep_symbols);
     free(mod->filename);
     free(mod->src_code);
     free(mod);
@@ -91,7 +91,7 @@ module* module_parse(char* path, module* parent)
 
         free(src_path);
         free(path);
-        module_free(mod);
+        module_free(mod, 0);
         
         return false;
     }
@@ -120,13 +120,13 @@ module* module_parse(char* path, module* parent)
     if (parser_status != 0)
     {
         printf("error: could not lex and/or parse %s\n", path);
-        module_free(mod);
+        module_free(mod, 0);
 		return 0;
     }
     
     if (!preprocessor_process(mod))
     {
-        module_free(mod);
+        module_free(mod, 0);
 		return 0;
     }
     

--- a/src/module.c
+++ b/src/module.c
@@ -32,13 +32,12 @@ void module_free(module* mod)
 
     if (mod->module_store != 0)
     {
-        for (size_t i = 0; i < mod->module_store->capacity; i++)
+        vector* modules_vec = hashtable_to_vector(mod->module_store);
+        for (int i = 0; i < modules_vec->size; i++)
         {
-            if (mod->module_store->keys[i] != 0)
-            {
-                module_free(mod->module_store->items[i]);
-            }
+            module_free(vector_get_item(modules_vec, i));
         }
+        vector_free(modules_vec);
         hashtable_free(mod->module_store);
     }
     if (mod->dependencies != 0)
@@ -89,7 +88,11 @@ module* module_parse(char* path, module* parent)
     if (!(src_path = path_locate_file(path, parent_dir)))
     {
         printf("error: could not find file %s\n", path);
+
         free(src_path);
+        free(path);
+        module_free(mod);
+        
         return false;
     }
 
@@ -262,16 +265,16 @@ void module_print_to_file(module* mod, FILE* file)
     {
         fprintf(file, ",\"modules\": [");
 
-        vector* module_vec = hashtable_to_vector(mod->module_store);
-        for (int i = 0; i < module_vec->size; i++)
+        vector* modules_vec = hashtable_to_vector(mod->module_store);
+        for (int i = 0; i < modules_vec->size; i++)
         {
-            module_print_to_file(vector_get_item(module_vec, i), file);
-            if (i < module_vec->size - 1) // don't print a comma after the last item
+            module_print_to_file(vector_get_item(modules_vec, i), file);
+            if (i < modules_vec->size - 1) // don't print a comma after the last item
             {
                 fprintf(file, ",");
             }
         }
-        vector_free(module_vec);
+        vector_free(modules_vec);
 
         fprintf(file, "]");
     }

--- a/src/module.c
+++ b/src/module.c
@@ -25,6 +25,11 @@ module* module_new()
 
 void module_free(module* mod)
 {
+    if (mod == 0)
+    {
+        return;
+    }
+
     if (mod->module_store != 0)
     {
         for (size_t i = 0; i < mod->module_store->capacity; i++)

--- a/src/module.h
+++ b/src/module.h
@@ -22,7 +22,7 @@ struct module
 module *module_new(void);
 // creates a new module from the given file, parent can be 0 but is required for include'd files
 module *module_parse(char *filename, module *parent);
-void module_free(module *mod);
+void module_free(module* mod, bool keep_symbols);
 
 void module_add_dependency(module *mod, module *dependency);
 // get the dependency from the specified module

--- a/src/preprocessor.c
+++ b/src/preprocessor.c
@@ -155,15 +155,17 @@ void combine_modules(preproc_state* state)
             ast_insert_child(state->mod->ast_root, j, node_copy); // insert at the start of the main ast_root
         }
 
-        // TODO: duplicate names across large codebases?
-        // copy root symbol table
-        vector* symbols_vec = hashtable_to_vector(dependency->ast_root->value.symbol_table);
-        for (int j = 0; j < symbols_vec->size; j++)
+        // copy dependency's root symbol table
+        for (int j = 0; j < dependency->ast_root->value.symbol_table->capacity; j++)
         {
-            symbol* sym = vector_get_item(symbols_vec, j);
-            hashtable_set_item(state->mod->ast_root->value.symbol_table, sym->name, sym);
+            if (dependency->ast_root->value.symbol_table->keys[j] != 0)
+            {
+                char* key = dependency->ast_root->value.symbol_table->keys[j];
+                symbol* sym = dependency->ast_root->value.symbol_table->items[j];
+
+                hashtable_set_item(state->mod->ast_root->value.symbol_table, key, sym);
+            }
         }
-        vector_free(symbols_vec);
 
         // delete the dependency module
         hashtable_delete_item(state->mod->dependencies, dependency->name);

--- a/src/preprocessor.c
+++ b/src/preprocessor.c
@@ -142,15 +142,23 @@ bool preprocessor_process(module* mod)
     state->mod = mod;
 
     build_symbols(state, mod->ast_root);
-    process_nodes(state, mod->ast_root);
+    if (state->error_counter > 0)
+	{
+        goto preproc_fail;
+	}
 
+    process_nodes(state, mod->ast_root);
 	if (state->error_counter > 0)
 	{
-		printf("total %ld preprocessor errors\n", state->error_counter);
-        preproc_state_free(state);
-		return false;
+        goto preproc_fail;
 	}
 
     preproc_state_free(state);
     return true;
+
+preproc_fail:
+	printf("total %ld preprocessor errors\n", state->error_counter);
+
+    preproc_state_free(state);
+    return false;
 }

--- a/src/preprocessor.h
+++ b/src/preprocessor.h
@@ -18,14 +18,14 @@ void preproc_state_free(preproc_state* state);
 bool preprocessor_process(module* mod);
 
 #define preproc_error( state, node, fmt, ... ) \
-    printf("%s\n", ast_find_closest_src_line(node)); \
+    printf("%s: %s\n", state->mod->name, ast_find_closest_src_line(node)); \
     printf("preprocessor error: "); \
     printf(fmt, ##__VA_ARGS__ ); \
     state->error_counter += 1
 
 #ifdef TIN_DEBUG_VERBOSE
     #define preproc_verb( state, node, fmt, ... ) \
-        printf("%s\n", ast_find_closest_src_line(node)); \
+        printf("%s: %s\n", state->mod->name, ast_find_closest_src_line(node)); \
         printf("preprocessor verb: "); \
         printf(fmt, ##__VA_ARGS__ )
 #else
@@ -33,7 +33,7 @@ bool preprocessor_process(module* mod);
 #endif
 
 #define preproc_warn( state, node, fmt, ... ) \
-    printf("%s\n", ast_find_closest_src_line(node)); \
+    printf("%s: %s\n", state->mod->name, ast_find_closest_src_line(node)); \
     printf("preprocessor warning: "); \
     printf(fmt, ##__VA_ARGS__ )
 

--- a/src/symbol.c
+++ b/src/symbol.c
@@ -27,6 +27,13 @@ void symbol_free(symbol* sym)
     free(sym);
 }
 
+char* symbol_generate_key(char* name, void* mod_ptr)
+{
+    char* key = malloc(16 + strlen(name) + 1); // max 16 hex characters for the pointer + name length + null terminator
+    sprintf(key, "%p%s", mod_ptr, name);
+    return key;
+}
+
 void symbol_print_to_file(symbol* sym, FILE* file)
 {
     fprintf(file, "{\"id\":\"%p\",\"name\":\"%s\",\"data_type\":\"%s\",\"data_type_pointer_level\":%ld,\"data_type_size\":%ld", sym, sym->name, sym->dtype->name, sym->dtype->pointer_level, sym->dtype->size);

--- a/src/symbol.c
+++ b/src/symbol.c
@@ -8,7 +8,7 @@ symbol* symbol_new(void)
 
     sym->name = 0;
 
-    sym->dtype;
+    sym->dtype = 0;
 
     sym->is_initialised = false;
     sym->is_function = false;

--- a/src/symbol.c
+++ b/src/symbol.c
@@ -2,11 +2,12 @@
 #include <stdlib.h>
 #include <string.h>
 
-symbol* symbol_new(void)
+symbol* symbol_new(char* name, void* mod_ptr)
 {
     symbol* sym = malloc(sizeof(symbol));
 
-    sym->name = 0;
+    sym->name = strdup(name);
+    sym->key = symbol_generate_key(name, mod_ptr);
 
     sym->dtype = 0;
 
@@ -23,20 +24,21 @@ void symbol_free(symbol* sym)
     }
 
     free(sym->name);
+    free(sym->key);
     data_type_free(sym->dtype);
     free(sym);
 }
 
 char* symbol_generate_key(char* name, void* mod_ptr)
 {
-    char* key = malloc(16 + strlen(name) + 1); // max 16 hex characters for the pointer + name length + null terminator
-    sprintf(key, "%p%s", mod_ptr, name);
+    char* key = malloc(2 + 16 + strlen(name) + 1); // 5 chars for the format + max 16 hex chars for the pointer + name length + null terminator
+    sprintf(key, "_%p_%s", mod_ptr, name);
     return key;
 }
 
 void symbol_print_to_file(symbol* sym, FILE* file)
 {
-    fprintf(file, "{\"id\":\"%p\",\"name\":\"%s\",\"data_type\":\"%s\",\"data_type_pointer_level\":%ld,\"data_type_size\":%ld", sym, sym->name, sym->dtype->name, sym->dtype->pointer_level, sym->dtype->size);
+    fprintf(file, "{\"key\":\"%s\",\"name\":\"%s\",\"data_type\":\"%s\",\"data_type_pointer_level\":%ld,\"data_type_size\":%ld", sym->key, sym->name, sym->dtype->name, sym->dtype->pointer_level, sym->dtype->size);
 
     if (sym->is_initialised)
     {

--- a/src/symbol.c
+++ b/src/symbol.c
@@ -17,6 +17,11 @@ symbol* symbol_new(void)
 
 void symbol_free(symbol* sym)
 {   
+    if (sym == 0)
+    {
+        return;
+    }
+
     free(sym->name);
     data_type_free(sym->dtype);
     free(sym);

--- a/src/symbol.h
+++ b/src/symbol.h
@@ -12,6 +12,7 @@
 typedef struct
 {
     char *name;
+    char *key;
 
     data_type *dtype;
 
@@ -21,7 +22,7 @@ typedef struct
     void *function_node; // for the interperter to follow function symbols
 } symbol;
 
-symbol *symbol_new(void);
+symbol *symbol_new(char* name, void* mod_ptr);
 void symbol_free(symbol *sym);
 
 // generates a unique key for the given symbol name in the given module/namepsaec

--- a/src/symbol.h
+++ b/src/symbol.h
@@ -24,6 +24,9 @@ typedef struct
 symbol *symbol_new(void);
 void symbol_free(symbol *sym);
 
+// generates a unique key for the given symbol name in the given module/namepsaec
+char* symbol_generate_key(char* name, void* mod_ptr);
+
 // prints a json representation of the symbol to the given file (can be stdout)
 void symbol_print_to_file(symbol *sym, FILE *file);
 

--- a/src/tin.c
+++ b/src/tin.c
@@ -30,13 +30,16 @@ int main(int argc, char **argv)
 		return 0;
 	}
 
+	print_step("Parsing main module\n");
 	module *mod = module_parse(argv[1], 0);
 
 	if (mod == 0) // parsing failed
 	{
+		print_step("Parsing and preprocessing failed\n");
 		goto end;
 	}
 	module_print_to_file(mod, 0);
+	print_step("Parsed and preprocessed the program successfully\n");
 
 #ifdef TIN_INTERPRETER
 	print_step("Running in interpreter mode\n");

--- a/src/tin.c
+++ b/src/tin.c
@@ -115,7 +115,7 @@ int main(int argc, char **argv)
 end:
 	if (mod != 0)
 	{
-		module_free(mod);
+		module_free(mod, 0);
 	}
 
 	return 0;

--- a/src/tin.c
+++ b/src/tin.c
@@ -112,10 +112,11 @@ int main(int argc, char **argv)
 #endif
 
 end:
-	if (mod != 0)
+	if (mod == 0)
 	{
-		module_free(mod, 0);
+		return 1; // failure
 	}
+	module_free(mod, 0);
 
 	return 0;
 }

--- a/src/tin.c
+++ b/src/tin.c
@@ -1,4 +1,3 @@
-#include "ast.h"
 #include "interpreter.h"
 #include "module.h"
 
@@ -59,7 +58,7 @@ int main(int argc, char **argv)
 		print_step("Compiling %s to %s\n", argv[1], codegen_output_name);
 
 		FILE *compiled_file = fopen(codegen_output_name, "wb");
-		codegen_generate(mod, mod->ast_root, compiled_file);
+		codegen_generate(mod, compiled_file);
 
 		fclose(compiled_file);
 		free(codegen_output_name);

--- a/src/tin.y
+++ b/src/tin.y
@@ -52,7 +52,7 @@ void yyerror (yyscan_t* locp, module* mod, const char* msg);
 %%
 
 program
-    : { $$ = mod->ast_root; } /* passed from main */
+    : { $$ = mod->ast_root; $$->src_line = module_get_src_line(mod, 0); } /* passed from main */
     | program statement { ast_add_child($1, $2); if ($2->src_line == 0) { $2->src_line = module_get_src_line(mod, yyget_lineno(scanner)); } }
     | program function  { ast_add_child($1, $2); }
     ;

--- a/src/tin.y
+++ b/src/tin.y
@@ -207,9 +207,9 @@ statement
     | jump_statement            { $$ = $1; }
     | scope                     { $$ = $1; }
     | ALLOC identifier expression SEMI_COLON    { $$ = ast_new(AstAlloc); ast_add_child($$, $2); ast_add_child($$, $3); }
-    | ASM STRING SEMI_COLON         { $$ = ast_new(AstAsm);  $$->value.string = strdup($2->value.string); ast_free($2); }
+    | ASM STRING SEMI_COLON         { $$ = ast_new(AstAsm);  $$->value.string = strdup($2->value.string); ast_free($2, 0); }
     | FREE expression SEMI_COLON    { $$ = ast_new(AstFree); ast_add_child($$, $2); }
-    | INCLUDE STRING                { $$ = ast_new(AstInclude); $$->value.string = strdup($2->value.string); ast_free($2); }
+    | INCLUDE STRING                { $$ = ast_new(AstInclude); $$->value.string = strdup($2->value.string); ast_free($2, 0); }
     | INPUT identifier SEMI_COLON   { $$ = ast_new(AstInput); ast_add_child($$, $2); }
     | PRINT expression SEMI_COLON   { $$ = ast_new(AstPrint); ast_add_child($$, $2); }
     ;

--- a/src/utils/hashtable.c
+++ b/src/utils/hashtable.c
@@ -59,6 +59,32 @@ void hashtable_free(hashtable* table)
     free(table->items);
     free(table);
 }
+hashtable* hashtable_copy(hashtable* table)
+{
+    hashtable* copy = malloc(sizeof(hashtable));
+
+    copy->size = 0;
+    copy->capacity = table->capacity;
+    
+    copy->keys = malloc(sizeof(char*) * table->capacity);
+    copy->items = malloc(sizeof(void*) * table->capacity);
+
+    for (int i = 0; i < table->capacity; i++)
+    {
+        if (table->keys[i] == 0)
+        {
+            copy->keys[i] = 0;
+            copy->items[i] = 0;
+        }
+        else
+        {
+            copy->keys[i] = strdup(table->keys[i]);
+            copy->items[i] = table->items[i];
+        }
+    }
+
+    return copy;
+}
 
 void hashtable_resize(hashtable* table)
 {

--- a/src/utils/hashtable.c
+++ b/src/utils/hashtable.c
@@ -42,6 +42,11 @@ hashtable* hashtable_new()
 }
 void hashtable_free(hashtable* table)
 {
+    if (table == 0)
+    {
+        return;
+    }
+
     for (int i = 0; i < table->capacity; i++)
     {
         if (table->keys[i] != 0)

--- a/src/utils/hashtable.c
+++ b/src/utils/hashtable.c
@@ -32,11 +32,8 @@ hashtable* hashtable_new()
     table->keys = malloc(sizeof(char*) * table->capacity);
     table->items = malloc(sizeof(void*) * table->capacity);
     
-    for (int i = 0; i < table->capacity; i++)
-    {
-        table->keys[i] = 0;
-        table->items[i] = 0;
-    }
+    memset(table->keys, 0, table->capacity);
+    memset(table->values, 0, table->capacity);
 
     return table;
 }
@@ -69,14 +66,12 @@ hashtable* hashtable_copy(hashtable* table)
     copy->keys = malloc(sizeof(char*) * table->capacity);
     copy->items = malloc(sizeof(void*) * table->capacity);
 
+    memset(copy->keys, 0, copy->capacity);
+    memset(copy->values, 0, copy->capacity);
+
     for (int i = 0; i < table->capacity; i++)
     {
-        if (table->keys[i] == 0)
-        {
-            copy->keys[i] = 0;
-            copy->items[i] = 0;
-        }
-        else
+        if (table->keys[i] != 0)
         {
             copy->keys[i] = strdup(table->keys[i]);
             copy->items[i] = table->items[i];
@@ -96,11 +91,8 @@ void hashtable_resize(hashtable* table)
     table->keys = malloc(sizeof(char*) * table->capacity);
     table->items = malloc(sizeof(void*) * table->capacity);
 
-    for (int i = 0; i < table->capacity; i++)
-    {
-        table->keys[i] = 0;
-        table->items[i] = 0;
-    }
+    memset(table->keys, 0, table->capacity);
+    memset(table->values, 0, table->capacity);
 
     for (int i = 0; i < old_capacity; i++)
     {

--- a/src/utils/hashtable.h
+++ b/src/utils/hashtable.h
@@ -23,6 +23,7 @@ void hashtable_resize(hashtable* table);
 size_t hashtable_find_slot(hashtable* table, char* key);
 void hashtable_set_item(hashtable* table, char* key, void* item);
 void* hashtable_get_item(hashtable* table, char* key);
+// do not forget that only the entry is freed, the memory being referenced will NOT be freed
 void hashtable_delete_item(hashtable* table, char* key);
 // returns a vector rendition of the hashtable, useful for iterating over all items
 vector* hashtable_to_vector(hashtable* table);

--- a/src/utils/hashtable.h
+++ b/src/utils/hashtable.h
@@ -16,10 +16,13 @@ struct hashtable
 
 hashtable* hashtable_new();
 void hashtable_free(hashtable* table);
+// do not forget that values will not be deep-copied
+hashtable* hashtable_copy(hashtable* table);
 
 void hashtable_resize(hashtable* table);
 size_t hashtable_find_slot(hashtable* table, char* key);
 void hashtable_set_item(hashtable* table, char* key, void* item);
 void* hashtable_get_item(hashtable* table, char* key);
 void hashtable_delete_item(hashtable* table, char* key);
+// returns a vector rendition of the hashtable, useful for iterating over all items
 vector* hashtable_to_vector(hashtable* table);

--- a/src/utils/path.c
+++ b/src/utils/path.c
@@ -1,5 +1,6 @@
 #include "path.h"
 #include <stdarg.h>
+#include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 
@@ -13,8 +14,6 @@ char* path_trunc(char* path)
 
 char* path_join(int count, ...)
 {
-    // TODO: ensure there are delimiter between elements
-
     int len = 0;
     char* path = malloc(PATH_MAX_LENGTH);
     path[0] = '\0';
@@ -27,6 +26,14 @@ char* path_join(int count, ...)
         char* arg = va_arg(args, char*);
         if (arg != 0)
         {
+            // if there is no delimiter on either the previous or current element, and the current element isn't an extension, add the delimiter
+            if (len > 0 && path[len - 1] != PATH_DELIM_UNIX && path[len - 1] != PATH_DELIM_WIN && arg[0] != PATH_DELIM_UNIX && arg[0] != PATH_DELIM_WIN && arg[0] != '.')
+            {
+                path[len] = PATH_DELIM;
+                path[len + 1] = '\0';
+                len += 1;
+            }
+
             strcat(path, arg);
             len += strlen(arg);
         }
@@ -88,4 +95,47 @@ char* path_get_filename_wo_ext(char* path)
     }
 
     return path_trunc(filename);
+}
+char* path_locate_file(char* path, char* parent_dir)
+{
+    char* new_path = 0;
+
+    // try to find the file locally
+    if (parent_dir != 0)
+    {
+        new_path = path_join(2, parent_dir, path);
+    }
+    else
+    {
+        new_path = strdup(path);
+    }
+
+    FILE* file;
+    if (file = fopen(new_path, "rb"))
+	{
+        fclose(file);
+        return new_path;
+	}
+
+    // try to find the file in PATH
+    char* env_path = getenv("PATH");
+    if (env_path == 0)
+    {
+        return 0;
+    }
+    
+    // split the PATH variable into seperate paths
+    char* split_path = strtok(env_path, ENV_PATH_DELIM);
+    while (split_path != 0)
+    {
+        char* joined_path = path_join(2, split_path, path);
+        if (file = fopen(joined_path, "rb"))
+        {
+            new_path = joined_path;
+            break;
+        }
+        split_path = strtok(NULL, ENV_PATH_DELIM);
+    }
+
+    return new_path;
 }

--- a/src/utils/path.c
+++ b/src/utils/path.c
@@ -116,6 +116,8 @@ char* path_locate_file(char* path, char* parent_dir)
         fclose(file);
         return new_path;
 	}
+    free(new_path);
+    new_path = 0;
 
     // try to find the file in PATH
     char* env_path = getenv("PATH");
@@ -123,7 +125,7 @@ char* path_locate_file(char* path, char* parent_dir)
     {
         return 0;
     }
-    
+
     // split the PATH variable into seperate paths
     char* split_path = strtok(env_path, ENV_PATH_DELIM);
     while (split_path != 0)
@@ -132,8 +134,10 @@ char* path_locate_file(char* path, char* parent_dir)
         if (file = fopen(joined_path, "rb"))
         {
             new_path = joined_path;
+            fclose(file);
             break;
         }
+        free(joined_path);
         split_path = strtok(NULL, ENV_PATH_DELIM);
     }
 

--- a/src/utils/path.h
+++ b/src/utils/path.h
@@ -1,12 +1,18 @@
 #pragma once
 
+// delimiter for directories in path
 #define PATH_DELIM_UNIX '/'
 #define PATH_DELIM_WIN '\\'
+// delimiter for paths in PATH env variable
+#define ENV_PATH_DELIM_UNIX ":"
+#define ENV_PATH_DELIM_WIN ";"
 
 #ifdef _WIN32
-    #define PATH_DELIM_DEFAULT PATH_DELIM_WIN
+    #define PATH_DELIM PATH_DELIM_WIN
+    #define ENV_PATH_DELIM ENV_PATH_DELIM_WIN
 #else
-    #define PATH_DELIM_DEFAULT PATH_DELIM_UNIX
+    #define PATH_DELIM PATH_DELIM_UNIX
+    #define ENV_PATH_DELIM ENV_PATH_DELIM_UNIX
 #endif
 
 #define PATH_MAX_LENGTH 1024
@@ -19,3 +25,5 @@ char* path_get_directory(char* path);
 char* path_get_filename(char* path);
 // gets the filename without the extension from the path
 char* path_get_filename_wo_ext(char* path);
+// finds the given relative path in either the working directory or PATH (standard library files), parent_dir can be 0
+char* path_locate_file(char* path, char* parent_dir);

--- a/src/utils/vector.c
+++ b/src/utils/vector.c
@@ -16,6 +16,11 @@ vector* vector_new()
 }
 void vector_free(vector* vec)
 {
+    if (vec == 0)
+    {
+        return;
+    }
+
     free(vec->items);
     free(vec);
 }

--- a/src/utils/vector.c
+++ b/src/utils/vector.c
@@ -11,7 +11,8 @@ vector* vector_new()
 
     // allocate space for item pointers
     vec->items = malloc(sizeof(vector*) * vec->capacity);
-    
+    memset(vec->items, 0, vec->capacity);
+
     return vec;
 }
 void vector_free(vector* vec)
@@ -31,6 +32,8 @@ vector* vector_copy(vector* vec)
     copy->size = vec->size;
     copy->capacity = vec->capacity;
     copy->items = malloc(sizeof(vector*) * vec->capacity);
+
+    memset(copy->items, 0, copy->capacity);
 
     for (size_t i = 0; i < vec->size; i++)
     {

--- a/src/utils/vector.h
+++ b/src/utils/vector.h
@@ -13,6 +13,7 @@ struct vector {
 
 vector* vector_new();
 void vector_free(vector* vec);
+// do not forget that values will not be deep-copied
 vector* vector_copy(vector* vec);
 
 void vector_resize(vector* vec);

--- a/std/std_example.tin
+++ b/std/std_example.tin
@@ -1,4 +1,4 @@
-fn ptr i8 get_str
+fn void print_str
 {
-    return "hello from the tin standard library";
+    print "hello from the tin standard library!\n";
 }

--- a/std/std_example.tin
+++ b/std/std_example.tin
@@ -1,0 +1,4 @@
+fn ptr i8 get_str
+{
+    return "hello from the tin standard library";
+}

--- a/units/include_test.tin
+++ b/units/include_test.tin
@@ -1,5 +1,6 @@
 include "include_test_example_1.tin"
 include "include_test_folder/include_test_example_3.tin"
+include "std_example.tin"
 
 fn i32 main
 {
@@ -7,6 +8,7 @@ fn i32 main
 
     print include_test_example_1::include_test_example_2::test_str;
     print include_test_example_3::test_str;
+    print std_example::get_str();
 
     return 0;
 }

--- a/units/include_test.tin
+++ b/units/include_test.tin
@@ -1,6 +1,6 @@
 include "include_test_example_1.tin"
-include "include_test_folder/include_test_example_3.tin"
-include "std_example.tin"
+include "include_test_folder/include_test_example_3"
+include "std_example"
 
 fn i32 main
 {

--- a/units/include_test.tin
+++ b/units/include_test.tin
@@ -4,11 +4,11 @@ include "std_example"
 
 fn i32 main
 {
-    include_test_example_1::test();
+    include_test_example_1::print_str();
+    include_test_example_1::include_test_example_2::print_str();
+    include_test_example_3::print_str();
 
-    print include_test_example_1::include_test_example_2::test_str;
-    print include_test_example_3::test_str;
-    print std_example::get_str();
+    std_example::print_str();
 
     return 0;
 }

--- a/units/include_test_example_1.tin
+++ b/units/include_test_example_1.tin
@@ -1,6 +1,6 @@
 include "include_test_folder/include_test_example_2.tin"
 
-fn void test
+fn void print_str
 {
-    include_test_example_2::test_str = "Hello world!";
+    print "hello from include_test_example_1!\n";
 }

--- a/units/include_test_folder/include_test_example_2.tin
+++ b/units/include_test_folder/include_test_example_2.tin
@@ -1,1 +1,4 @@
-ptr i8 test_str;
+fn void print_str
+{
+    print "hello from include_test_example_2!\n";
+}

--- a/units/include_test_folder/include_test_example_3.tin
+++ b/units/include_test_folder/include_test_example_3.tin
@@ -1,1 +1,4 @@
-ptr i8 test_str = "world hello!";
+fn void print_str
+{
+    print "hello from include_test_example_3!\n";
+}


### PR DESCRIPTION
The compiler can now look for referenced files in directories specified in the PATH env variable, one of which should be our standard library directory. Additionally, the include example is now compliable and fully working, allowing us to start working on basic libraries.